### PR TITLE
feat: add support for ignoring existing patch with `--ignore-existing`

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A better and interactive `pnpm patch`.
 ## Usage
 
 ```bash
-npx pnpm-patch-i package-name
+npx pnpm-patch-i [--ignore-existing] package-name
 ```
 
 This CLI wraps with [`pnpm patch`](https://pnpm.io/cli/patch) and provide a better interactive experience:
@@ -16,6 +16,7 @@ This CLI wraps with [`pnpm patch`](https://pnpm.io/cli/patch) and provide a bett
 - More human-friendly folder name instead of random string
 - Open the editing folder in your editor via [`launch-editor`](https://github.com/yyx990803/launch-editor)
 - Wait for your changes and automatically run `pnpm commit-patch <dir>` for you
+- Support the `--ignore-existing` option to ignore existing patch (requires at least `pnpm@7.25.0`)
 
 ## Sponsors
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A better and interactive `pnpm patch`.
 ## Usage
 
 ```bash
-npx pnpm-patch-i [--ignore-existing] package-name
+npx pnpm-patch-i package-name
 ```
 
 This CLI wraps with [`pnpm patch`](https://pnpm.io/cli/patch) and provide a better interactive experience:
@@ -16,7 +16,6 @@ This CLI wraps with [`pnpm patch`](https://pnpm.io/cli/patch) and provide a bett
 - More human-friendly folder name instead of random string
 - Open the editing folder in your editor via [`launch-editor`](https://github.com/yyx990803/launch-editor)
 - Wait for your changes and automatically run `pnpm commit-patch <dir>` for you
-- Support the `--ignore-existing` option to ignore existing patch (requires at least `pnpm@7.25.0`)
 
 ## Sponsors
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,8 +1,12 @@
 import { startPatch } from '.'
 
-if (!process.argv[2]) {
-  console.error('$ pnpm-patch-i <package-name>')
+const args = process.argv.slice(2)
+const name = args[args.length === 1 ? 0 : 1]
+const ignoreExisting = args[0] === '--ignore-existing'
+
+if (!name) {
+  console.error('$ pnpm-patch-i [--ignore-existing] <package-name>')
   process.exit(1)
 }
 
-startPatch(process.argv[2])
+startPatch(name, ignoreExisting)

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,12 +1,11 @@
 import { startPatch } from '.'
 
-const args = process.argv.slice(2)
-const name = args[args.length === 1 ? 0 : 1]
-const ignoreExisting = args[0] === '--ignore-existing'
+const options = process.argv.slice(2)
+const name = options.pop()
 
 if (!name) {
-  console.error('$ pnpm-patch-i [--ignore-existing] <package-name>')
+  console.error('$ pnpm-patch-i <package-name>')
   process.exit(1)
 }
 
-startPatch(name, ignoreExisting)
+startPatch(name, options)

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,10 +8,15 @@ import c from 'picocolors'
 
 const nanoid = customAlphabet('1234567890abcdef', 10)
 
-export async function startPatch(name: string) {
+export async function startPatch(name: string, ignoreExisting = false) {
   const dir = `node_modules/.patch-edits/patch_edit_${name.replace(/\//g, '+')}_${nanoid()}`
 
-  await execa('pnpm', ['patch', '--edit-dir', dir, name], { stdout: 'ignore', stderr: 'inherit' })
+  const options = ['--edit-dir', dir]
+
+  if (ignoreExisting)
+    options.push('--ignore-existing')
+
+  await execa('pnpm', ['patch', ...options, name], { stdout: 'ignore', stderr: 'inherit' })
   await launch(dir)
 
   console.log(`Edit your patch for ${c.bold(c.yellow(name))} under ${c.green(dir)}\n`)

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,15 +8,10 @@ import c from 'picocolors'
 
 const nanoid = customAlphabet('1234567890abcdef', 10)
 
-export async function startPatch(name: string, ignoreExisting = false) {
+export async function startPatch(name: string, options: string[]) {
   const dir = `node_modules/.patch-edits/patch_edit_${name.replace(/\//g, '+')}_${nanoid()}`
 
-  const options = ['--edit-dir', dir]
-
-  if (ignoreExisting)
-    options.push('--ignore-existing')
-
-  await execa('pnpm', ['patch', ...options, name], { stdout: 'ignore', stderr: 'inherit' })
+  await execa('pnpm', ['patch', ...options, '--edit-dir', dir, name], { stdout: 'ignore', stderr: 'inherit' })
   await launch(dir)
 
   console.log(`Edit your patch for ${c.bold(c.yellow(name))} under ${c.green(dir)}\n`)


### PR DESCRIPTION
First, thanks for the tool, it makes the `pnpm patch` workflow much more pleasant.

### Description

In `pnpm@7.25.0`, [a change](https://github.com/pnpm/pnpm/pull/5906) was made to `pnpm patch` to apply an existing patch when patching a dependency that is already patched *(note: this only works when using the `pnpm patch <pkg name>@<version>` syntax, not the `pnpm patch <pkg name>` syntax)*.

This change works great with `pnpm-patch-i` altho, it also introduced a new option `--ignore-existing` to explicitely disable that new behavior and ignore an existing patch.

This pull request adds support for this option to `pnpm-patch-i`. I used the same option name as `pnpm patch` to keep things simple.

### Additional context

Here is a video demo of running `pnpx pnpm-patch-i is-odd@3.0.1` on `is-odd` with an already existing patch:

<video src="https://user-images.githubusercontent.com/494699/213152476-4e0a501d-61ae-40b1-91c4-3cf3dd2a769e.mp4"></video>

Here is a video demo of running `pnpx pnpm-patch-i --ignore-existing is-odd@3.0.1` on `is-odd` with an already existing patch:

<video src="https://user-images.githubusercontent.com/494699/213153212-ad48460c-aca7-428e-ad0f-2199c045d1e9.mp4"></video>