### PR TITLE
fix:  keep the package version info for the patch

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "find-up": "^7.0.0",
     "fs-extra": "^11.2.0",
     "launch-editor": "^2.6.1",
+    "local-pkg": "^0.5.0",
     "micromatch": "^4.0.7",
     "nanoid": "^5.0.7",
     "pathe": "^1.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       launch-editor:
         specifier: ^2.6.1
         version: 2.6.1
+      local-pkg:
+        specifier: ^0.5.0
+        version: 0.5.0
       micromatch:
         specifier: ^4.0.7
         version: 4.0.7


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

After the pnpm v9.7.0, pnpm-patch-i lost the patch version.

with this pr

before:
```json
"pnpm": {
    "patchedDependencies": {
        "foo": "foo.patch"
    }
}
```

after:
```json
"pnpm": {
    "patchedDependencies": {
        "foo@1.2.3": "foo@1.2.3.patch"
    }
}
```

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
