### PR TITLE
feat: replace picocolors with ansis

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "ansis": "^3.12.0",
     "cac": "^6.7.14",
     "execa": "^9.2.0",
     "find-up": "^7.0.0",
@@ -61,7 +62,6 @@
     "micromatch": "^4.0.7",
     "nanoid": "^5.0.7",
     "pathe": "^1.1.2",
-    "picocolors": "^1.0.1",
     "prompts": "^2.4.2"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      ansis:
+        specifier: ^3.12.0
+        version: 3.12.0
       cac:
         specifier: ^6.7.14
         version: 6.7.14
@@ -32,9 +35,6 @@ importers:
       pathe:
         specifier: ^1.1.2
         version: 1.1.2
-      picocolors:
-        specifier: ^1.0.1
-        version: 1.0.1
       prompts:
         specifier: ^2.4.2
         version: 2.4.2
@@ -1133,6 +1133,10 @@ packages:
   ansi-styles@6.2.1:
     resolution: {integrity: sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==}
     engines: {node: '>=12'}
+
+  ansis@3.12.0:
+    resolution: {integrity: sha512-SxhlInpMkv9QCyI2yHyrhVrTF8dH93M/S86DT5f9brFgr92uJLOCg0RNmtx3YKWKcRmNAaU+gyUfHMdUiqxvFw==}
+    engines: {node: '>=14'}
 
   anymatch@3.1.3:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
@@ -3954,6 +3958,8 @@ snapshots:
   ansi-styles@5.2.0: {}
 
   ansi-styles@6.2.1: {}
+
+  ansis@3.12.0: {}
 
   anymatch@3.1.3:
     dependencies:

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ import { findUp } from 'find-up'
 
 // @ts-expect-error missing types
 import launch from 'launch-editor'
-import c from 'picocolors'
+import c from 'ansis'
 
 const nanoid = customAlphabet('1234567890abcdef', 10)
 
@@ -46,7 +46,7 @@ export async function startPatch(options: StartPatchOptions) {
     if (build)
       throw new Error('--build is not supported when sourceDir is not specified')
 
-    console.log(`Edit your patch for ${c.bold(c.yellow(name))} under ${c.green(editDir)}\n`)
+    console.log(`Edit your patch for ${c.bold.yellow(name)} under ${c.green(editDir)}\n`)
 
     const confirm = yes || await prompts([{
       name: 'confirm',


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
Hello @antfu ,

This PR replaces `picocolors` with a better alternative `ansis` that supports both CJS and ESM.
Ansis supports chained syntax for clean and readable code.
Ansis is nearly as small (6.8 kB) as Picocolors (6.4 kB).
