### PR TITLE
feat: resolve workspace: and catalog: protocols when syncing package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,13 @@ npx pnpm-patch-i vite ../vite/packages/vite
 
 You can also use `--build` (`-b`) flag to invoke `npm run build` in the source directory before applying the patch.
 
+When merging the source `package.json` into the patched package, `workspace:` and `catalog:` dependency specifiers are resolved automatically:
+
+- `workspace:*` / `workspace:^` / `workspace:~` / `workspace:<range>` → reuses the version already present in the patched package's existing entry.
+- `catalog:` / `catalog:<name>` → looked up in the source repo's `pnpm-workspace.yaml` catalog definitions.
+
 > [!NOTE]
-> If the source package is in a monorepo with custom linking, or using catalogs, directly applying the patch from a directory might resulting copying the linking where the current project might not be able to resolve.
+> If the source package is in a monorepo with custom linking, directly applying the patch from a directory might result in copying the linking where the current project might not be able to resolve.
 > In that case, it's recommended to pack the source package into a tgz file and apply the patch from the tgz file with `--pack` (`-p`) flag.
 
 ## Sponsors

--- a/package.json
+++ b/package.json
@@ -62,7 +62,8 @@
     "micromatch": "^4.0.8",
     "nanoid": "^5.1.6",
     "pathe": "^2.0.3",
-    "prompts": "^2.4.2"
+    "prompts": "^2.4.2",
+    "yaml": "^2.8.3"
   },
   "devDependencies": {
     "@antfu/eslint-config": "^6.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,10 +38,13 @@ importers:
       prompts:
         specifier: ^2.4.2
         version: 2.4.2
+      yaml:
+        specifier: ^2.8.3
+        version: 2.8.3
     devDependencies:
       '@antfu/eslint-config':
         specifier: ^6.2.0
-        version: 6.2.0(@vue/compiler-sfc@3.4.15)(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)(vitest@4.0.5(@types/debug@4.1.12)(@types/node@24.9.2)(jiti@2.6.1)(tsx@4.20.6)(yaml@2.8.1))
+        version: 6.2.0(@vue/compiler-sfc@3.4.15)(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)(vitest@4.0.5(@types/debug@4.1.12)(@types/node@24.9.2)(jiti@2.6.1)(tsx@4.20.6)(yaml@2.8.3))
       '@antfu/ni':
         specifier: ^27.0.1
         version: 27.0.1
@@ -83,10 +86,10 @@ importers:
         version: 3.6.1(typescript@5.9.3)
       vite:
         specifier: ^7.1.12
-        version: 7.1.12(@types/node@24.9.2)(jiti@2.6.1)(tsx@4.20.6)(yaml@2.8.1)
+        version: 7.1.12(@types/node@24.9.2)(jiti@2.6.1)(tsx@4.20.6)(yaml@2.8.3)
       vitest:
         specifier: ^4.0.5
-        version: 4.0.5(@types/debug@4.1.12)(@types/node@24.9.2)(jiti@2.6.1)(tsx@4.20.6)(yaml@2.8.1)
+        version: 4.0.5(@types/debug@4.1.12)(@types/node@24.9.2)(jiti@2.6.1)(tsx@4.20.6)(yaml@2.8.3)
 
 packages:
 
@@ -2660,12 +2663,8 @@ packages:
     resolution: {integrity: sha512-E/+VitOorXSLiAqtTd7Yqax0/pAS3xaYMP+AUUJGOK1OZG3rhcj9fcJOM5HJ2VrP1FrStVCWr1muTfQCdj4tAA==}
     engines: {node: ^14.17.0 || >=16.0.0}
 
-  yaml@2.1.1:
-    resolution: {integrity: sha512-o96x3OPo8GjWeSLF+wOAbrPfhFOGY0W00GNaxCDv+9hkcDJEnev1yh8S7pgHF0ik6zc8sQLuL8hjHjJULZp8bw==}
-    engines: {node: '>= 14'}
-
-  yaml@2.8.1:
-    resolution: {integrity: sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==}
+  yaml@2.8.3:
+    resolution: {integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==}
     engines: {node: '>= 14.6'}
     hasBin: true
 
@@ -2688,7 +2687,7 @@ snapshots:
 
   '@aashutoshrathi/word-wrap@1.2.6': {}
 
-  '@antfu/eslint-config@6.2.0(@vue/compiler-sfc@3.4.15)(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)(vitest@4.0.5(@types/debug@4.1.12)(@types/node@24.9.2)(jiti@2.6.1)(tsx@4.20.6)(yaml@2.8.1))':
+  '@antfu/eslint-config@6.2.0(@vue/compiler-sfc@3.4.15)(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)(vitest@4.0.5(@types/debug@4.1.12)(@types/node@24.9.2)(jiti@2.6.1)(tsx@4.20.6)(yaml@2.8.3))':
     dependencies:
       '@antfu/install-pkg': 1.1.0
       '@clack/prompts': 0.11.0
@@ -2697,7 +2696,7 @@ snapshots:
       '@stylistic/eslint-plugin': 5.5.0(eslint@9.38.0(jiti@2.6.1))
       '@typescript-eslint/eslint-plugin': 8.46.2(@typescript-eslint/parser@8.46.2(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)
       '@typescript-eslint/parser': 8.46.2(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)
-      '@vitest/eslint-plugin': 1.4.0(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)(vitest@4.0.5(@types/debug@4.1.12)(@types/node@24.9.2)(jiti@2.6.1)(tsx@4.20.6)(yaml@2.8.1))
+      '@vitest/eslint-plugin': 1.4.0(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)(vitest@4.0.5(@types/debug@4.1.12)(@types/node@24.9.2)(jiti@2.6.1)(tsx@4.20.6)(yaml@2.8.3))
       ansis: 4.2.0
       cac: 6.7.14
       eslint: 9.38.0(jiti@2.6.1)
@@ -3277,14 +3276,14 @@ snapshots:
       '@typescript-eslint/types': 8.46.2
       eslint-visitor-keys: 4.2.1
 
-  '@vitest/eslint-plugin@1.4.0(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)(vitest@4.0.5(@types/debug@4.1.12)(@types/node@24.9.2)(jiti@2.6.1)(tsx@4.20.6)(yaml@2.8.1))':
+  '@vitest/eslint-plugin@1.4.0(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)(vitest@4.0.5(@types/debug@4.1.12)(@types/node@24.9.2)(jiti@2.6.1)(tsx@4.20.6)(yaml@2.8.3))':
     dependencies:
       '@typescript-eslint/scope-manager': 8.46.2
       '@typescript-eslint/utils': 8.46.2(eslint@9.38.0(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.38.0(jiti@2.6.1)
     optionalDependencies:
       typescript: 5.9.3
-      vitest: 4.0.5(@types/debug@4.1.12)(@types/node@24.9.2)(jiti@2.6.1)(tsx@4.20.6)(yaml@2.8.1)
+      vitest: 4.0.5(@types/debug@4.1.12)(@types/node@24.9.2)(jiti@2.6.1)(tsx@4.20.6)(yaml@2.8.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -3297,13 +3296,13 @@ snapshots:
       chai: 6.2.0
       tinyrainbow: 3.0.3
 
-  '@vitest/mocker@4.0.5(vite@7.1.12(@types/node@24.9.2)(jiti@2.6.1)(tsx@4.20.6)(yaml@2.8.1))':
+  '@vitest/mocker@4.0.5(vite@7.1.12(@types/node@24.9.2)(jiti@2.6.1)(tsx@4.20.6)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 4.0.5
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.1.12(@types/node@24.9.2)(jiti@2.6.1)(tsx@4.20.6)(yaml@2.8.1)
+      vite: 7.1.12(@types/node@24.9.2)(jiti@2.6.1)(tsx@4.20.6)(yaml@2.8.3)
 
   '@vitest/pretty-format@4.0.5':
     dependencies:
@@ -3449,7 +3448,7 @@ snapshots:
       semver: 7.7.3
       tinyexec: 1.0.1
       tinyglobby: 0.2.15
-      yaml: 2.8.1
+      yaml: 2.8.3
     transitivePeerDependencies:
       - magicast
 
@@ -4807,7 +4806,7 @@ snapshots:
 
   pnpm-workspace-yaml@1.3.0:
     dependencies:
-      yaml: 2.8.1
+      yaml: 2.8.3
 
   pnpm@10.20.0: {}
 
@@ -5315,7 +5314,7 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  vite@7.1.12(@types/node@24.9.2)(jiti@2.6.1)(tsx@4.20.6)(yaml@2.8.1):
+  vite@7.1.12(@types/node@24.9.2)(jiti@2.6.1)(tsx@4.20.6)(yaml@2.8.3):
     dependencies:
       esbuild: 0.25.11
       fdir: 6.5.0(picomatch@4.0.3)
@@ -5328,12 +5327,12 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.6.1
       tsx: 4.20.6
-      yaml: 2.8.1
+      yaml: 2.8.3
 
-  vitest@4.0.5(@types/debug@4.1.12)(@types/node@24.9.2)(jiti@2.6.1)(tsx@4.20.6)(yaml@2.8.1):
+  vitest@4.0.5(@types/debug@4.1.12)(@types/node@24.9.2)(jiti@2.6.1)(tsx@4.20.6)(yaml@2.8.3):
     dependencies:
       '@vitest/expect': 4.0.5
-      '@vitest/mocker': 4.0.5(vite@7.1.12(@types/node@24.9.2)(jiti@2.6.1)(tsx@4.20.6)(yaml@2.8.1))
+      '@vitest/mocker': 4.0.5(vite@7.1.12(@types/node@24.9.2)(jiti@2.6.1)(tsx@4.20.6)(yaml@2.8.3))
       '@vitest/pretty-format': 4.0.5
       '@vitest/runner': 4.0.5
       '@vitest/snapshot': 4.0.5
@@ -5350,7 +5349,7 @@ snapshots:
       tinyexec: 0.3.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vite: 7.1.12(@types/node@24.9.2)(jiti@2.6.1)(tsx@4.20.6)(yaml@2.8.1)
+      vite: 7.1.12(@types/node@24.9.2)(jiti@2.6.1)(tsx@4.20.6)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/debug': 4.1.12
@@ -5407,11 +5406,9 @@ snapshots:
   yaml-eslint-parser@1.3.0:
     dependencies:
       eslint-visitor-keys: 3.4.3
-      yaml: 2.1.1
+      yaml: 2.8.3
 
-  yaml@2.1.1: {}
-
-  yaml@2.8.1: {}
+  yaml@2.8.3: {}
 
   yocto-queue@0.1.0: {}
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import mm from 'micromatch'
 import { customAlphabet } from 'nanoid/non-secure'
 import { join, relative, resolve } from 'pathe'
 import prompts from 'prompts'
+import { parse as parseYaml } from 'yaml'
 
 const nanoid = customAlphabet('1234567890abcdef', 10)
 
@@ -66,7 +67,8 @@ export async function startPatch(options: StartPatchOptions) {
     }
   }
   else {
-    let sourcePath = resolve(cwd, sourceDir)
+    const originalSourcePath = resolve(cwd, sourceDir)
+    let sourcePath = originalSourcePath
     let sourcePkg = await fs.readJSON(join(sourcePath, 'package.json'))
 
     const confirm = yes || await prompts([{
@@ -129,23 +131,29 @@ export async function startPatch(options: StartPatchOptions) {
 
     const localPkg = await fs.readJSON(join(editDir, 'package.json'))
 
-    if (sourcePkg.dependencies)
-      localPkg.dependencies = handleDeps(localPkg.dependencies, sourcePkg.dependencies)
-    if (sourcePkg.devDependencies)
-      localPkg.devDependencies = handleDeps(localPkg.devDependencies, sourcePkg.devDependencies)
-    if (sourcePkg.peerDependencies)
-      localPkg.peerDependencies = handleDeps(localPkg.peerDependencies, sourcePkg.peerDependencies)
-    if (sourcePkg.optionalDependencies)
-      localPkg.optionalDependencies = handleDeps(localPkg.optionalDependencies, sourcePkg.optionalDependencies)
+    const catalogs = pack ? undefined : await readSourceCatalogs(originalSourcePath)
 
-    function handleDeps(local: Record<string, string> = {}, overrides?: Record<string, string>) {
+    if (sourcePkg.dependencies)
+      localPkg.dependencies = handleDeps(localPkg.dependencies, sourcePkg.dependencies, catalogs)
+    if (sourcePkg.devDependencies)
+      localPkg.devDependencies = handleDeps(localPkg.devDependencies, sourcePkg.devDependencies, catalogs)
+    if (sourcePkg.peerDependencies)
+      localPkg.peerDependencies = handleDeps(localPkg.peerDependencies, sourcePkg.peerDependencies, catalogs)
+    if (sourcePkg.optionalDependencies)
+      localPkg.optionalDependencies = handleDeps(localPkg.optionalDependencies, sourcePkg.optionalDependencies, catalogs)
+
+    function handleDeps(
+      local: Record<string, string> = {},
+      overrides: Record<string, string> | undefined,
+      catalogs: Catalogs | undefined,
+    ) {
       if (!overrides)
         return undefined
       const extraKeys = Object.keys(local).filter(k => !Object.keys(overrides).includes(k))
       for (const key of extraKeys)
         delete local[key]
       for (const [key, value] of Object.entries(overrides))
-        local[key] = value
+        local[key] = resolveDepValue(key, value, local[key], catalogs)
       return local
     }
 
@@ -155,4 +163,64 @@ export async function startPatch(options: StartPatchOptions) {
   console.log(c.blue('\nCommiting patch...'))
 
   await execa('pnpm', ['patch-commit', editDir], { stdio: 'inherit', cwd })
+}
+
+interface Catalogs {
+  default: Record<string, string>
+  named: Record<string, Record<string, string>>
+}
+
+async function readSourceCatalogs(sourcePath: string): Promise<Catalogs | undefined> {
+  const workspaceFile = await findUp('pnpm-workspace.yaml', { cwd: sourcePath })
+  if (!workspaceFile)
+    return undefined
+  try {
+    const raw = await fs.readFile(workspaceFile, 'utf8')
+    const data = parseYaml(raw) ?? {}
+    return {
+      default: data.catalog ?? {},
+      named: data.catalogs ?? {},
+    }
+  }
+  catch (err) {
+    console.warn(c.yellow(`Failed to read catalogs from ${workspaceFile}: ${(err as Error).message}`))
+    return undefined
+  }
+}
+
+function resolveDepValue(
+  name: string,
+  value: string,
+  localValue: string | undefined,
+  catalogs: Catalogs | undefined,
+): string {
+  if (value.startsWith('workspace:')) {
+    if (localValue) {
+      console.log(c.dim(`  resolved ${name}: ${value} → ${localValue}`))
+      return localValue
+    }
+    const suffix = value.slice('workspace:'.length)
+    if (suffix && !'*^~'.includes(suffix)) {
+      console.log(c.dim(`  resolved ${name}: ${value} → ${suffix}`))
+      return suffix
+    }
+    console.warn(c.yellow(`  could not resolve ${name}: ${value} (no local version), keeping literal`))
+    return value
+  }
+  if (value.startsWith('catalog:')) {
+    const catalogName = value.slice('catalog:'.length)
+    const table = catalogName ? catalogs?.named[catalogName] : catalogs?.default
+    const resolved = table?.[name]
+    if (resolved) {
+      console.log(c.dim(`  resolved ${name}: ${value} → ${resolved}`))
+      return resolved
+    }
+    console.warn(c.yellow(`  could not resolve ${name}: ${value} (no matching catalog entry), keeping literal`))
+    return value
+  }
+  const protocolMatch = value.match(/^([a-z][a-z+-]*):/i)
+  if (protocolMatch) {
+    console.warn(c.yellow(`  ${name}: ${value} uses unrecognized protocol "${protocolMatch[1]}:", keeping literal — the consumer may not be able to resolve it`))
+  }
+  return value
 }


### PR DESCRIPTION
## Summary

When applying a patch directly from a source directory (without `--pack`), `workspace:` and `catalog:` dependency specifiers in the source `package.json` previously leaked through into the patched package, leaving versions the consumer could not resolve. This PR resolves them inline:

- `workspace:*` / `^` / `~` / `<range>` → reuses the version already present in the patched package's existing entry (with `workspace:1.2.3` falling back to the literal version when no local entry exists).
- `catalog:` / `catalog:<name>` → looked up in the source repo's `pnpm-workspace.yaml` (`catalog` for default, `catalogs.<name>` for named).
- Other unrecognized protocols (`npm:`, `link:`, `file:`, `git+ssh:`, etc.) keep their literal value but emit a yellow warning naming the protocol.

`--pack` mode skips catalog lookup since `pnpm pack` already resolves both protocols. Each resolution emits a dim log line so the user can see what changed. Adds `yaml` as a dependency for parsing `pnpm-workspace.yaml`.

## Test plan

- [ ] Run `pnpm typecheck`, `pnpm lint`, `pnpm build`
- [ ] Patch a real package whose source uses `workspace:` and `catalog:` deps without `--pack`; confirm the resulting `package.json` has resolved versions
- [ ] Re-run the same case with `--pack` and confirm no resolution log lines appear
- [ ] Spot-check edge cases: missing `pnpm-workspace.yaml`, unknown catalog name, unrecognized protocol

🤖 Generated with [Claude Code](https://claude.com/claude-code)